### PR TITLE
ci: add CI workflow to run tests and mypy on push/PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,49 @@
+name: CI
+
+on:
+  push:
+    branches: ["**"]
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  typecheck:
+    name: Typecheck
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+      - name: Install dependencies
+        run: uv sync
+      - name: Mypy
+        run: uv run --with mypy mypy teslemetry_stream
+
+  test:
+    name: Test (Python ${{ matrix.python-version }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+      - name: Set up Python ${{ matrix.python-version }}
+        run: uv python install ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: uv sync --python ${{ matrix.python-version }}
+      - name: Run tests
+        run: |
+          for f in tests/test_*.py; do
+            echo "Running $f"
+            uv run python "$f"
+          done

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,15 @@
+# Project agent memory
+
+This file is the project's committed home for project-intrinsic agent knowledge: build, test, release, architecture, and sharp-edge notes that should travel with the code.
+
+- Add durable project-specific notes here as they are discovered through real work.
+- CI runs on push/PR: `.github/workflows/ci.yml`. Uses `uv` (see `uv.lock`).
+- `tests/` files are plain scripts (`if __name__ == "__main__"`), not pytest-based - pytest would collect zero tests here. Run each directly, e.g. `uv run python tests/test_field_type_coercion.py`.
+- `pyproject.toml` has a `[tool.mypy]` config but no dev-dependency group declares mypy, so `uv sync` alone won't install it. CI installs it ephemerally via `uv run --with mypy mypy teslemetry_stream`.
+
+## Maintaining this file
+
+Keep this file for knowledge useful to almost every future agent session in this project.
+Do not repeat what the codebase already shows; point to the authoritative file or command instead.
+Prefer rewriting or pruning existing entries over appending new ones.
+When updating this file, preserve this bar for all agents and keep entries concise.


### PR DESCRIPTION
## Intent
- Bootstrap CI: this repo has tests and a pyproject but no workflow runs them - the tag-triggered PyPI publish (`python-publish.yml`) ships with zero validation gate.
  - Adds `.github/workflows/ci.yml` running on `push` + `pull_request`.
  - Modeled on the fleet's reference CI (`python-tesla-fleet-api`, `aiopowerwall`): `astral-sh/setup-uv`, `uv sync`, matrix test job.
- Tooling choices matched to what this repo actually has, not introduced new:
  - Install: `uv sync` (repo already uses `uv.lock`).
  - Typecheck: `mypy` is already configured via `[tool.mypy]` in `pyproject.toml` but isn't declared as a dependency anywhere (no dev dependency group exists). Ran via `uv run --with mypy mypy teslemetry_stream` (ephemeral install) rather than adding a dev-dependency group, to avoid touching tooling config in a CI-bootstrap PR.
  - Lint: skipped - no ruff/flake8/etc. config exists in this repo, so none was introduced.
  - Tests: the existing `tests/test_field_type_coercion.py` is a plain script (`if __name__ == "__main__"`), not pytest-based - pytest would collect zero tests here since none of its functions are `test_`-prefixed. CI runs each `tests/test_*.py` directly via `uv run python`, matching the repo's actual test convention.
- Python matrix: `3.9`-`3.13`, matching `requires-python = ">=3.9"` (no classifiers narrow this further).
- Explicitly out of scope (per one-issue-per-PR): `python-publish.yml` / the publish path is untouched. Wiring CI as a required gate before publish is a possible follow-up.

## Testing
- Ran both CI commands locally before pushing: `uv sync`, `uv run --with mypy mypy teslemetry_stream` (passes, one pre-existing warning that mypy no longer supports the `python_version = "3.9"` target in `[tool.mypy]` - unrelated to this PR, not fixed here since it's a tooling-config change), and `uv run python tests/test_field_type_coercion.py` (all checks pass).
- Workflow itself validated by CI running green on this PR (see checks below).

<details><summary>Full narrative / original brief</summary>

E10.1 follow-up, from the fleet CI audit. Top finding for this repo: tests and pyproject exist but NO CI workflow runs them - the repo publishes to PyPI on tag with zero validation gate. Scope: add `.github/workflows/ci.yml` running on push + PR, matching the repo's tooling (uv), only add lint/typecheck if already configured (no new tool configs), Python matrix matching `requires-python`, modeled on `python-tesla-fleet-api` / `aiopowerwall` CI. Do not touch `python-publish.yml` in this PR.

</details>
