### PR TITLE
chore: sync uv.lock to 0.9.2

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -612,7 +612,7 @@ wheels = [
 
 [[package]]
 name = "teslemetry-stream"
-version = "0.8.2"
+version = "0.9.2"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Intent

`pyproject.toml`'s version was bumped to 0.9.2 in #12, but `uv.lock` was never regenerated, so the locked `teslemetry-stream` package entry still reads 0.8.2. `uv lock` to bring it back in sync.
