### PR TITLE
chore: bump version to 0.10.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ requires = ["setuptools>=77.0"]
 
 [project]
 name = "teslemetry_stream"
-version = "0.9.2"
+version = "0.10.0"
 license = "Apache-2.0"
 description = "Teslemetry Streaming API library for Python"
 readme = "README.md"

--- a/uv.lock
+++ b/uv.lock
@@ -612,7 +612,7 @@ wheels = [
 
 [[package]]
 name = "teslemetry-stream"
-version = "0.9.2"
+version = "0.10.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Intent

Bump `version` to `0.10.0` for release, covering the SSE topics allowlist, `tariff_content_v2`, slim `site_info`, and the typed `energy_totals` listener (#13-#17) — all feature-level additions with no breaking change to existing listeners. Also regenerates `uv.lock` so the locked `teslemetry-stream` entry stays in sync (see #14 for precedent).
