### PR TITLE
ci(release): disable PEP 740 attestations on PyPI publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -104,6 +104,9 @@ jobs:
           path: dist/
       - name: Publish distribution to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          # Reusable workflow: PEP 740 attestations sign under the top-level caller's identity, which PyPI's publisher-identity check rejects with a 400.
+          attestations: false
 
   github-release:
     name: Upload distribution to GitHub Release


### PR DESCRIPTION
## Intent

- Disable PEP 740 attestations on the PyPI publish step.
  - This exact failure just hit python-tesla-fleet-api's release: with a reusable `workflow_call` release workflow, attestations sign under the top-level caller's identity, but PyPI verifies against the publisher identity, so the upload gets rejected with a 400.
  - This repo's `release.yml` shares the identical reusable-workflow shape, so it would fail the same way on its next tag.
