### PR TITLE
chore: bump version to 0.10.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ requires = ["setuptools>=77.0"]
 
 [project]
 name = "teslemetry_stream"
-version = "0.10.0"
+version = "0.10.1"
 license = "Apache-2.0"
 description = "Teslemetry Streaming API library for Python"
 readme = "README.md"


### PR DESCRIPTION
Patch release for the SSE stream lifecycle hardening (#23) - bug fixes only, no public API changes.