### PR TITLE
chore: refresh uv.lock to match pyproject version

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -612,7 +612,7 @@ wheels = [
 
 [[package]]
 name = "teslemetry-stream"
-version = "0.10.0"
+version = "0.10.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
uv.lock's self-referential `teslemetry-stream` entry was still pinned at 0.10.0 after pyproject.toml moved to 0.10.1, so `uv sync` reported a stale lockfile. Refreshes it to match.