### PR TITLE
fix: decode PassengerSeatBelt as BuckleStatus enum, not a bool

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ requires = ["setuptools>=77.0"]
 
 [project]
 name = "teslemetry_stream"
-version = "0.12.0"
+version = "0.11.1"
 license = "Apache-2.0"
 description = "Teslemetry Streaming API library for Python"
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ requires = ["setuptools>=77.0"]
 
 [project]
 name = "teslemetry_stream"
-version = "0.11.0"
+version = "0.12.0"
 license = "Apache-2.0"
 description = "Teslemetry Streaming API library for Python"
 readme = "README.md"

--- a/teslemetry_stream/const.py
+++ b/teslemetry_stream/const.py
@@ -597,7 +597,7 @@ BMSState = TeslemetryEnum(
 
 # Unused
 BuckleStatus = TeslemetryEnum(
-    "BuckleStatus", ["Unknown", "Unlatched", "Latched", "Faulted"]
+    "BuckleStatus", ["Unknown", "Unlatched", "Latched", "Faulted", "SNA"]
 )
 
 CarType = TeslemetryEnum(

--- a/teslemetry_stream/vehicle.py
+++ b/teslemetry_stream/vehicle.py
@@ -12,6 +12,7 @@ import aiohttp
 
 from .const import (
     BMSState,
+    BuckleStatus,
     CabinOverheatProtectionModeState,
     CableType,
     CarType,
@@ -1301,10 +1302,14 @@ class TeslemetryStreamVehicle:
     def listen_DriverSeatBelt(
         self, callback: Callable[[bool | None], None]
     ) -> Callable[[], None]:
-        """Listen for Driver Seat Belt."""
+        """Listen for Driver Seat Belt.
+
+        True only when the driver seat is occupied and its belt is undone -
+        this is the safety-warning condition, not raw belt state.
+        """
         self._enable_field(Signal.DRIVER_SEAT_BELT)
         return self.stream.async_add_listener(
-            make_bool(Signal.DRIVER_SEAT_BELT, callback),  # BuckleStatus?
+            make_bool(Signal.DRIVER_SEAT_BELT, callback),
             {"vin": self.vin, "data": {Signal.DRIVER_SEAT_BELT: None}},
         )
 
@@ -1946,12 +1951,18 @@ class TeslemetryStreamVehicle:
         )
 
     def listen_PassengerSeatBelt(
-        self, callback: Callable[[bool | None], None]
+        self, callback: Callable[[str | None], None]
     ) -> Callable[[], None]:
-        """Listen for Passenger Seat Belt."""
+        """Listen for Passenger Seat Belt.
+
+        Despite the name, this reports the 2nd row centre belt, not the
+        front passenger belt.
+        """
         self._enable_field(Signal.PASSENGER_SEAT_BELT)
         return self.stream.async_add_listener(
-            make_bool(Signal.PASSENGER_SEAT_BELT, callback),
+            lambda x: callback(
+                BuckleStatus.get(x["data"][Signal.PASSENGER_SEAT_BELT])
+            ),
             {"vin": self.vin, "data": {Signal.PASSENGER_SEAT_BELT: None}},
         )
 

--- a/uv.lock
+++ b/uv.lock
@@ -612,7 +612,7 @@ wheels = [
 
 [[package]]
 name = "teslemetry-stream"
-version = "0.12.0"
+version = "0.11.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },

--- a/uv.lock
+++ b/uv.lock
@@ -612,7 +612,7 @@ wheels = [
 
 [[package]]
 name = "teslemetry-stream"
-version = "0.11.0"
+version = "0.12.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Intent

- `listen_PassengerSeatBelt` was typed `Callable[[bool | None], None]` and wrapped `make_bool`, but the wire value is the `BuckleStatus` enum (`Unknown`/`Unlatched`/`Latched`/`Faulted`/`SNA`). `make_bool`'s string handling is just `data == "true"`, which none of those values ever match, so every consumer received a permanently-false boolean with no way to recover the real state.
  - Fixed by decoding through `BuckleStatus.get`, following the existing lookup-map pattern already used by `listen_DetailedChargeState`.
  - **Breaking:** the callback type changes from `bool | None` to `str | None`. Bumped to 0.11.1 (patch): the field never returned a usable value, so this is a bugfix to broken behavior rather than a change to a working contract, and we only just bumped to 0.11.0 nine days ago. Regenerated `uv.lock` to match.
  - Added the missing `SNA` option to `BuckleStatus` in `const.py`.
- Corrected both seat belt docstrings against a live telemetry session:
  - `PassengerSeatBelt` reports the 2nd row centre belt, not the front passenger belt.
  - `DriverSeatBelt` is `true` only when the driver seat is occupied *and* its belt is undone (the safety-warning condition), not raw belt state.
  - Removed the stale `# BuckleStatus?` comment - it sat on the driver listener (a plain bool) instead of the passenger one it was actually asking about.
- Swept the rest of `vehicle.py`'s `make_bool` call sites for other enum-valued fields wrapped the same way; none of the other `Signal` names match a defined `TeslemetryEnum`, so this looks like the only instance of the defect.
