### PR TITLE
feat: type listen_Credits with a CreditsEvent dataclass

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,7 +249,7 @@ Add listener for data updates.
 ### `listen(self)`
 Listen to the telemetry stream.
 
-### `listen_Credits(callback: Callable[[dict[str, str | int]], None]) -> Callable[[], None]`
+### `listen_Credits(callback: Callable[[CreditsEvent], None]) -> Callable[[], None]`
 Add listener for credit events.
 
 ### `listen_Balance(callback: Callable[[int], None]) -> Callable[[], None]`

--- a/teslemetry_stream/const.py
+++ b/teslemetry_stream/const.py
@@ -424,6 +424,33 @@ class EnergyHistoryTotals:
 
 
 @dataclass
+class CreditsEvent:
+    """A credits accounting event.
+
+    `quota` is carried through as the server sends it rather than typed
+    field-by-field - every observed payload has shipped it empty, so there
+    is no evidence yet of what it contains when populated.
+    """
+
+    type: str
+    cost: int
+    name: str
+    balance: int
+    quota: dict[str, Any]
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> CreditsEvent:
+        """Build from the event's `credits` dict."""
+        return cls(
+            type=data["type"],
+            cost=data["cost"],
+            name=data["name"],
+            balance=data["balance"],
+            quota=data.get("quota", {}),
+        )
+
+
+@dataclass
 class TeslaLocation:
     """Location data"""
 

--- a/teslemetry_stream/stream.py
+++ b/teslemetry_stream/stream.py
@@ -9,6 +9,7 @@ from typing import Any, cast
 
 import aiohttp
 
+from .const import CreditsEvent
 from .energysite import TeslemetryStreamEnergySite
 from .exception import TeslemetryStreamEnded
 from .vehicle import TeslemetryStreamVehicle
@@ -462,7 +463,7 @@ class TeslemetryStream:
         LOGGER.debug("Listen has finished")
 
     def listen_Credits(
-        self, callback: Callable[[dict[str, str | int]], None]
+        self, callback: Callable[[CreditsEvent], None]
     ) -> Callable[[], None]:
         """
         Listen for credits update.
@@ -471,7 +472,7 @@ class TeslemetryStream:
         :return: Function to remove the listener.
         """
         return self.async_add_listener(
-            lambda x: callback(x["credits"]), {"credits": None}
+            lambda x: callback(CreditsEvent.from_dict(x["credits"])), {"credits": None}
         )
 
     def listen_Balance(self, callback: Callable[[int], None]) -> Callable[[], None]:


### PR DESCRIPTION
## Intent

- `listen_Credits` was typed `Callable[[dict[str, str | int]], None]` - a bare, incomplete dict shape (it doesn't even account for the `quota` key, which isn't a `str | int`). Callers had to hand-parse the dict with no static guarantee of what keys exist.
  - Added `CreditsEvent` in `const.py` as a `@dataclass`, following the same construct as `EnergyHistoryTotals` (a `from_dict` classmethod building it from the event's nested dict).
  - Fields (`type: str`, `cost: int`, `name: str`, `balance: int`, `quota: dict[str, Any]`) are drawn from the one real fixture in `tests/test_energysite_events.py` (`CREDITS_EVENT`), all required since nothing in that sample is omitted.
  - `quota` is kept as `dict[str, Any]` rather than a nested dataclass - every observed payload ships it empty, so there's no evidence yet of its internal shape.
  - `listen_Credits` now returns `CreditsEvent` instead of the bare dict. Purely additive from the caller's perspective (a plain function still works); the callback's payload shape changes, so this is worth a version bump on release.
